### PR TITLE
PopulateDatabase will populate the new jobstats.gpuinfo

### DIFF
--- a/PopulateDatabase
+++ b/PopulateDatabase
@@ -75,7 +75,7 @@ def getSlurmAccountUsers(acc):
         List of account user names. None of account doesn't exist/no users
         belong to it.
     """
-    out = subprocess.getstatusoutput('sshare -a -P')[1].split('\n')
+    out = subprocess.getstatusoutput('ssh jfg95@monsoon.hpc.nau.edu sshare -a -P')[1].split('\n')
     users = []
 
     for i in out:
@@ -91,7 +91,7 @@ def getSlurmAccounts():
     """
     Desc: Retrieve a list of all available slurm accounts in the cluster
     """
-    out = subprocess.getstatusoutput('sshare -l -P')[1].split('\n')[1::]
+    out = subprocess.getstatusoutput('ssh jfg95@monsoon.hpc.nau.edu sshare -l -P')[1].split('\n')[1::]
     accounts = []
 
     for i in out:
@@ -162,7 +162,7 @@ def getJobStats(cursor, user, account, start_date_time, track_single_core_jobs):
         List containing the stats for memory, cores, timelimit, and total,
         respectively.
     """
-    cmd = 'jobstats -o Comment,End,AllocGRES -p'  # Add in username and make parsable
+    cmd = 'ssh jfg95@monsoon.hpc.nau.edu /home/jfg95/jobstats/jobstats/jobstats -o Comment,End,AllocGRES -p'  # Add in username and make parsable
     cmd += " -u {0} -A {1}".format(user, account)
 
     if start_date_time:
@@ -184,10 +184,10 @@ def getJobStats(cursor, user, account, start_date_time, track_single_core_jobs):
         'tlimit-use': None,
         'job-count':  job_count
     }
+    print("res = " + str(res))
 
     # Get the resources required/used per job
     for job in res:
-        print(job)
         job = job.split('|')
         # Skip failed jobs
         if len(job) != 13 or job[0] == 'JobID':
@@ -285,33 +285,6 @@ def getJobStats(cursor, user, account, start_date_time, track_single_core_jobs):
                     gpustats['idealgpu'])
             cursor.execute(statement, args)
 
-        # add row to gpuinfo (1 row per job)
-        gpustats = dict()
-        gpustats['username'] = user
-        gpustats['account'] = account
-        gpustats['date'] = job[10][0:job[10].index('T')]
-        gpustats['jobid'] = job[0]
-        comment = job[9]
-        allocGRES = job[11]
-        gpuinfo = None
-        try:
-            gpuinfo = json.loads(comment)
-        except:
-            pass
-        if gpuinfo is not None and allocGRES.find('gpu') != -1:
-            gpustats['ngpu'] = gpuinfo['ngpu']
-            gpustats['gputime'] = 60.0 * gpuinfo['step'] * gpuinfo['ngpu'] * gpuinfo['gpu_util'] / 100.0
-            gpustats['idealgpu'] = gpuinfo['ngpu'] * tlimit_req
-
-            # insert query
-            statement = 'INSERT IGNORE INTO gpuinfo ' + \
-                '(username,account,date,jobid,ngpu,gputime,idealgpu) ' + \
-                'VALUES (%s, %s, %s, %s, %s, %s, %s)'
-            args = (gpustats['username'], gpustats['account'], gpustats['date'],
-                    gpustats['jobid'], gpustats['ngpu'], gpustats['gputime'],
-                    gpustats['idealgpu'])
-            cursor.execute(statement, args)
-
     return user_stats
 
 
@@ -380,14 +353,17 @@ if __name__ == '__main__':
         user_total = len(getSlurmAccountUsers(account))
         user_num = 1
         for user in getSlurmAccountUsers(account):
+            print("account " + str(account_num) + "/" + str(account_total) + " (" + account + ") , user " + str(user_num) + "/" + str(user_total) + " (" + user + ")")
             stats = getJobStats(cursor,
                                 user,
                                 account,
                                 from_date,
                                 TRACK_SINGLE_CORE_JOBS)
 
+            print("job-count = " + str(stats['job-count']))
             if stats['job-count'] != 0:
                 updateDatabase(user, account, stats, from_date, cursor)
+            print()
             user_num += 1
         account_num += 1
 

--- a/PopulateDatabase
+++ b/PopulateDatabase
@@ -21,7 +21,48 @@ from datetime import timedelta
 import mysql.connector as mariadb
 import configparser
 import os
+import json
 
+def timeStringToSeconds(timeString):
+    """
+    Desc: Convert a time string to seconds total elapsed.
+
+    Args:
+        timeString (string): Timestamp of the form 'D-HH:MM:SS.SSS'
+
+    Returns:
+        Integer or floating point representation of seconds elapsed.
+    """
+    rightDecimal = 0
+    timeInSeconds = 0
+    timeIndex = 0
+
+    timeParsed = timeString.split('.')
+
+    if len(timeParsed) > 1:
+        timeInSeconds += float('0.' + timeParsed[1])
+
+    timeParsed = timeParsed[0]
+    
+    timeParsed = re.split('-|:', timeParsed)
+
+    # Does elapsed contain days? (*1-*00:00:00)
+    if len(timeParsed) == 4:
+        timeInSeconds += int(timeParsed[0]) * 24 * 60 * 60
+
+    # Does time contain hours?
+    if len(timeParsed) >= 3:
+        timeInSeconds += int(timeParsed[-3]) * 60 * 60  # Hours
+
+    # Does time contain minutes?
+    if len(timeParsed) >= 2:
+        timeInSeconds += int(timeParsed[-2]) * 60       # Minutes
+    
+    # Does time contain seconds?
+    if len(timeParsed) >= 1:
+        timeInSeconds += int(timeParsed[-1])            # Seconds
+
+    return timeInSeconds
 
 def getSlurmAccountUsers(acc):
     """
@@ -106,9 +147,10 @@ def timeStringToSeconds(time_string):
     return time_in_seconds
 
 
-def getJobStats(user, account, start_date_time=None):
+def getJobStats(cursor, user, account, start_date_time=None):
     """
-    Desc: Retrieve the job stats for a list of users.
+    Desc: Retrieve the job stats for a list of users, and populate the gpuinfo
+          table
 
     Args:
         user (string): User to search.
@@ -120,7 +162,7 @@ def getJobStats(user, account, start_date_time=None):
         List containing the stats for memory, cores, timelimit, and total,
         respectively.
     """
-    cmd = 'jobstats -p'  # Add in username and make parsable
+    cmd = 'jobstats -o Comment,End,AllocGRES -p'  # Add in username and make parsable
 
     cmd += " -u {0} -A {1}".format(user, account)
 
@@ -146,18 +188,20 @@ def getJobStats(user, account, start_date_time=None):
 
     # Get the resources required/used per job
     for job in res:
+        print(job)
         job = job.split('|')
         # Skip failed jobs
-        if len(job) != 10 or job[8] != 'COMPLETED':
+        if len(job) < 13 or job[8] != 'COMPLETED':
             user_stats['job-count'] -= 1
             continue
 
-        mem_req    = None
-        mem_use    = None
-        core_req   = None 
-        cpu_time   = None
-        tlimit_req = None
-        tlimit_use = None
+        mem_req       = None
+        mem_use       = None
+        core_req      = None 
+        cpu_time      = None
+        tlimit_req    = None
+        tlimit_use    = None
+        comment       = None # contains GPU usage info
 
         try:
             mem_req = int(job[2].replace('M', ''))
@@ -210,6 +254,33 @@ def getJobStats(user, account, start_date_time=None):
         except:
             pass
 
+        # add row to gpuinfo (1 row per job)
+        gpustats = dict()
+        gpustats['username'] = user
+        gpustats['account'] = account
+        gpustats['date'] = job[10][0:job[10].index('T')]
+        gpustats['jobid'] = job[0]
+        comment = job[9]
+        allocGRES = job[11]
+        gpuinfo = None
+        try:
+            gpuinfo = json.loads(comment)
+        except:
+            pass
+        if gpuinfo is not None and allocGRES.find('gpu') != -1:
+            gpustats['ngpu'] = gpuinfo['ngpu']
+            gpustats['gputime'] = 60.0 * gpuinfo['step'] * gpuinfo['ngpu'] * gpuinfo['gpu_util'] / 100.0
+            gpustats['idealgpu'] = gpuinfo['ngpu'] * tlimit_req
+
+            # insert query
+            statement = 'INSERT IGNORE INTO gpuinfo ' + \
+                '(username,account,date,jobid,ngpu,gputime,idealgpu) ' + \
+                'VALUES (%s, %s, %s, %s, %s, %s, %s)'
+            args = (gpustats['username'], gpustats['account'], gpustats['date'],
+                    gpustats['jobid'], gpustats['ngpu'], gpustats['gputime'],
+                    gpustats['idealgpu'])
+            cursor.execute(statement, args)
+
     return user_stats
 
 
@@ -232,7 +303,6 @@ def updateDatabase(user, account, stats, date, cursor):
     args = (user, account, date, stats['ideal-cpu-time'], stats['memory-req'],
             stats['tlimit-req'], stats['cpu-time'], stats['tlimit-use'],
             stats['memory-use'], stats['job-count'])
-
     cursor.execute(statement, args)
 
 
@@ -273,7 +343,8 @@ if __name__ == '__main__':
             continue
 
         for user in getSlurmAccountUsers(account):
-            stats = getJobStats(user, account, start_date_time=from_date)
+            stats = getJobStats(cursor, user, account,
+                                start_date_time=from_date)
 
             if stats['job-count'] != 0:
                 print(user, stats)

--- a/PopulateDatabase
+++ b/PopulateDatabase
@@ -198,15 +198,14 @@ def getJobStats(user, account, start_date_time=None):
             core_req = int(job[4])
             cpu_time = float(timeStringToSeconds(job[5]))
         
-            if core_req > 1:
-                if not user_stats['ideal-cpu-time']:
-                    user_stats['ideal-cpu-time'] = 0   
+            if not user_stats['ideal-cpu-time']:
+                user_stats['ideal-cpu-time'] = 0   
 
-                if not user_stats['cpu-time']:
-                    user_stats['cpu-time'] = 0
+            if not user_stats['cpu-time']:
+                user_stats['cpu-time'] = 0
 
-                user_stats['ideal-cpu-time'] += (core_req * tlimit_use)
-                user_stats['cpu-time']  += cpu_time
+            user_stats['ideal-cpu-time'] += (core_req * tlimit_use)
+            user_stats['cpu-time']  += cpu_time
 
         except:
             pass

--- a/PopulateDatabase
+++ b/PopulateDatabase
@@ -21,7 +21,48 @@ from datetime import timedelta
 import mysql.connector as mariadb
 import configparser
 import os
+import json
 
+def timeStringToSeconds(timeString):
+    """
+    Desc: Convert a time string to seconds total elapsed.
+
+    Args:
+        timeString (string): Timestamp of the form 'D-HH:MM:SS.SSS'
+
+    Returns:
+        Integer or floating point representation of seconds elapsed.
+    """
+    rightDecimal = 0
+    timeInSeconds = 0
+    timeIndex = 0
+
+    timeParsed = timeString.split('.')
+
+    if len(timeParsed) > 1:
+        timeInSeconds += float('0.' + timeParsed[1])
+
+    timeParsed = timeParsed[0]
+    
+    timeParsed = re.split('-|:', timeParsed)
+
+    # Does elapsed contain days? (*1-*00:00:00)
+    if len(timeParsed) == 4:
+        timeInSeconds += int(timeParsed[0]) * 24 * 60 * 60
+
+    # Does time contain hours?
+    if len(timeParsed) >= 3:
+        timeInSeconds += int(timeParsed[-3]) * 60 * 60  # Hours
+
+    # Does time contain minutes?
+    if len(timeParsed) >= 2:
+        timeInSeconds += int(timeParsed[-2]) * 60       # Minutes
+    
+    # Does time contain seconds?
+    if len(timeParsed) >= 1:
+        timeInSeconds += int(timeParsed[-1])            # Seconds
+
+    return timeInSeconds
 
 def getSlurmAccountUsers(acc):
     """
@@ -106,9 +147,10 @@ def timeStringToSeconds(time_string):
     return time_in_seconds
 
 
-def getJobStats(user, account, start_date_time=None):
+def getJobStats(cursor, user, account, start_date_time, track_single_core_jobs):
     """
-    Desc: Retrieve the job stats for a list of users.
+    Desc: Retrieve the job stats for a list of users, and populate the gpuinfo
+          table
 
     Args:
         user (string): User to search.
@@ -120,8 +162,7 @@ def getJobStats(user, account, start_date_time=None):
         List containing the stats for memory, cores, timelimit, and total,
         respectively.
     """
-    cmd = 'jobstats -p'  # Add in username and make parsable
-
+    cmd = 'jobstats -o Comment,End,AllocGRES -p'  # Add in username and make parsable
     cmd += " -u {0} -A {1}".format(user, account)
 
     if start_date_time:
@@ -148,16 +189,17 @@ def getJobStats(user, account, start_date_time=None):
     for job in res:
         job = job.split('|')
         # Skip failed jobs
-        if len(job) != 10 or job[8] != 'COMPLETED':
+        if len(job) != 13 or job[0] == 'JobID':
             user_stats['job-count'] -= 1
             continue
 
-        mem_req    = None
-        mem_use    = None
-        core_req   = None 
-        cpu_time   = None
-        tlimit_req = None
-        tlimit_use = None
+        mem_req       = None
+        mem_use       = None
+        core_req      = None 
+        cpu_time      = None
+        tlimit_req    = None
+        tlimit_use    = None
+        comment       = None # contains GPU usage info
 
         try:
             mem_req = int(job[2].replace('M', ''))
@@ -197,18 +239,50 @@ def getJobStats(user, account, start_date_time=None):
         try:
             core_req = int(job[4])
             cpu_time = float(timeStringToSeconds(job[5]))
+
+            if core_req > 1 or track_single_core_jobs:
+                if not user_stats['ideal-cpu-time']:
+                    user_stats['ideal-cpu-time'] = 0   
+
+                if not user_stats['cpu-time']:
+                    user_stats['cpu-time'] = 0
+
+                user_stats['ideal-cpu-time'] += (core_req * tlimit_use)
+                user_stats['cpu-time']  += cpu_time            
         
-            if not user_stats['ideal-cpu-time']:
-                user_stats['ideal-cpu-time'] = 0   
-
-            if not user_stats['cpu-time']:
-                user_stats['cpu-time'] = 0
-
-            user_stats['ideal-cpu-time'] += (core_req * tlimit_use)
-            user_stats['cpu-time']  += cpu_time
-
         except:
             pass
+
+        # add row to gpuinfo (1 row per job)
+        gpustats = dict()
+        gpustats['username'] = user
+        gpustats['account'] = account
+        gpustats['date'] = job[10][0:job[10].index('T')]
+        gpustats['jobid'] = job[0]
+        comment = job[9]
+        allocGRES = job[11]
+        gpuinfo = None
+        try:
+            gpuinfo = json.loads(comment)
+        except:
+            pass
+        if gpuinfo is not None and allocGRES.find('gpu') != -1:
+            gpustats['ngpu'] = gpuinfo['ngpu']
+            gpustats['gputime'] = 60.0 * gpuinfo['step'] * gpuinfo['ngpu'] * gpuinfo['gpu_util'] / 100.0
+            try:
+                gpustats['idealgpu'] = gpuinfo['ngpu'] * tlimit_use
+            except:
+                # tlimit_use must be None
+                gpustats['idealgpu'] = gpuinfo['ngpu'] * 60.0 * gpuinfo['step']
+
+            # insert query
+            statement = 'INSERT IGNORE INTO gpuinfo ' + \
+                '(username,account,date,jobid,ngpu,gputime,idealgpu) ' + \
+                'VALUES (%s, %s, %s, %s, %s, %s, %s)'
+            args = (gpustats['username'], gpustats['account'], gpustats['date'],
+                    gpustats['jobid'], gpustats['ngpu'], gpustats['gputime'],
+                    gpustats['idealgpu'])
+            cursor.execute(statement, args)
 
     return user_stats
 
@@ -232,7 +306,6 @@ def updateDatabase(user, account, stats, date, cursor):
     args = (user, account, date, stats['ideal-cpu-time'], stats['memory-req'],
             stats['tlimit-req'], stats['cpu-time'], stats['tlimit-use'],
             stats['memory-use'], stats['job-count'])
-
     cursor.execute(statement, args)
 
 
@@ -243,11 +316,14 @@ if __name__ == '__main__':
     username = None
     password = None
     host     = None
+    TRACK_SINGLE_CORE_JOBS = False
+    
 
     try:
         username = config['jobstats-db']['username']
         host     = config['jobstats-db']['host']
         password = config['jobstats-db']['password']
+        TRACK_SINGLE_CORE_JOBS = config['jobstats-db']['TRACK_SINGLE_CORE_JOBS'] == 'True'
 
     except:
         print("Error: configuration values not found")
@@ -263,23 +339,30 @@ if __name__ == '__main__':
     print("Processing jobs for", from_date)
 
     accounts = getSlurmAccounts()
-    conn = mariadb.connect(user=username, password=password, host=host)
+    conn = mariadb.connect(user=username, password=password, host=host, autocommit=True)
     cursor = conn.cursor()
 
     cursor.execute('USE jobstats')
+    account_total = len(accounts)
+    account_num = 1
 
     for account in accounts:
         if account == 'orphan':
             continue
-
+        user_total = len(getSlurmAccountUsers(account))
+        user_num = 1
         for user in getSlurmAccountUsers(account):
-            stats = getJobStats(user, account, start_date_time=from_date)
+            stats = getJobStats(cursor,
+                                user,
+                                account,
+                                from_date,
+                                TRACK_SINGLE_CORE_JOBS)
 
             if stats['job-count'] != 0:
-                print(user, stats)
                 updateDatabase(user, account, stats, from_date, cursor)
-    
+            user_num += 1
+        account_num += 1
 
-    conn.commit()
+    conn.commit()    
     cursor.close()
     conn.close()

--- a/PopulateDatabase
+++ b/PopulateDatabase
@@ -75,7 +75,7 @@ def getSlurmAccountUsers(acc):
         List of account user names. None of account doesn't exist/no users
         belong to it.
     """
-    out = subprocess.getstatusoutput('ssh jfg95@monsoon.hpc.nau.edu sshare -a -P')[1].split('\n')
+    out = subprocess.getstatusoutput('sshare -a -P')[1].split('\n')
     users = []
 
     for i in out:
@@ -91,7 +91,7 @@ def getSlurmAccounts():
     """
     Desc: Retrieve a list of all available slurm accounts in the cluster
     """
-    out = subprocess.getstatusoutput('ssh jfg95@monsoon.hpc.nau.edu sshare -l -P')[1].split('\n')[1::]
+    out = subprocess.getstatusoutput('sshare -l -P')[1].split('\n')[1::]
     accounts = []
 
     for i in out:
@@ -162,7 +162,7 @@ def getJobStats(cursor, user, account, start_date_time, track_single_core_jobs):
         List containing the stats for memory, cores, timelimit, and total,
         respectively.
     """
-    cmd = 'ssh jfg95@monsoon.hpc.nau.edu /home/jfg95/jobstats/jobstats/jobstats -o Comment,End,AllocGRES -p'  # Add in username and make parsable
+    cmd = 'jobstats -o Comment,End,AllocGRES -p'  # Add in username and make parsable
     cmd += " -u {0} -A {1}".format(user, account)
 
     if start_date_time:
@@ -184,7 +184,6 @@ def getJobStats(cursor, user, account, start_date_time, track_single_core_jobs):
         'tlimit-use': None,
         'job-count':  job_count
     }
-    print("res = " + str(res))
 
     # Get the resources required/used per job
     for job in res:
@@ -345,27 +344,20 @@ if __name__ == '__main__':
 
     cursor.execute('USE jobstats')
     account_total = len(accounts)
-    account_num = 1
 
     for account in accounts:
         if account == 'orphan':
             continue
         user_total = len(getSlurmAccountUsers(account))
-        user_num = 1
         for user in getSlurmAccountUsers(account):
-            print("account " + str(account_num) + "/" + str(account_total) + " (" + account + ") , user " + str(user_num) + "/" + str(user_total) + " (" + user + ")")
             stats = getJobStats(cursor,
                                 user,
                                 account,
                                 from_date,
                                 TRACK_SINGLE_CORE_JOBS)
 
-            print("job-count = " + str(stats['job-count']))
             if stats['job-count'] != 0:
                 updateDatabase(user, account, stats, from_date, cursor)
-            print()
-            user_num += 1
-        account_num += 1
 
     conn.commit()    
     cursor.close()


### PR DESCRIPTION
I couldn't test this code directly on my doppler VM. I used ssh to run commands on monsoon (like jobstats) and I used debugging print statements which are not needed here. Below is the diff:

```
[doppler@dopplervm jobstats-db]$ diff PopulateDatabase PopulateDatabase_debug 
78c78
<     out = subprocess.getstatusoutput('sshare -a -P')[1].split('\n')
---
>     out = subprocess.getstatusoutput('ssh jfg95@monsoon.hpc.nau.edu sshare -a -P')[1].split('\n')
94c94
<     out = subprocess.getstatusoutput('sshare -l -P')[1].split('\n')[1::]
---
>     out = subprocess.getstatusoutput('ssh jfg95@monsoon.hpc.nau.edu sshare -l -P')[1].split('\n')[1::]
165c165
<     cmd = 'jobstats -o Comment,End,AllocGRES -p'  # Add in username and make parsable
---
>     cmd = 'ssh jfg95@monsoon.hpc.nau.edu /home/jfg95/jobstats/jobstats/jobstats -o Comment,End,AllocGRES -p'  # Add in username and make parsable
186a187
>     print("res = " + str(res))
346a348
>     account_num = 1
351a354
>         user_num = 1
352a356
>             print("account " + str(account_num) + "/" + str(account_total) + " (" + account + ") , user " + str(user_num) + "/" + str(user_total) + " (" + user + ")")
358a363
>             print("job-count = " + str(stats['job-count']))
360a366,368
>             print()
>             user_num += 1
>         account_num += 1
[doppler@dopplervm jobstats-db]$
```

Note: Need "TRACK_SINGLE_CORE_JOBS=False" argument in the config file